### PR TITLE
Add GoReleaser and Homebrew

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+export GITHUB_TOKEN=""
+export GITHUB_PERSONAL_AUTH_TOKEN=""
+
+source_env_if_exists .envrc-personal

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /.idea/
+
+dist/
+/.envrc-personal

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,51 @@
+before:
+    hooks:
+        - go mod tidy
+builds:
+    -   binary: unique
+        env:
+            - CGO_ENABLED=0
+        goos:
+            - linux
+            - darwin
+snapshot:
+    name_template: "{{ incpatch .Version }}-next"
+changelog:
+    sort: asc
+    filters:
+        exclude:
+            - '^docs:'
+            - '^test:'
+
+brews:
+    -   name: unique
+        alternative_names:
+            - unique@{{ .Version }}
+            - unique@{{ .Major }}.{{ .Minor }}
+            - unique@{{ .Major }}
+        description: "unique is a simple tool that outputs the unique lines of its input"
+        homepage: "https://github.com/ro-tex/unique"
+        license: "MIT"
+        folder: Formula
+        download_strategy: CurlDownloadStrategy
+        url_template: "https://github.com/ro-tex/unique/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+        commit_author:
+            name: goreleaserbot
+            email: bot@goreleaser.com
+        commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+        dependencies:
+            -   name: go
+        repository:
+            owner: ro-tex
+            name: homebrew-tap
+            branch: main
+            token: "{{ .Env.GITHUB_PERSONAL_AUTH_TOKEN }}"
+            git:
+                url: 'https://github.com/ro-tex/homebrew-tap.git'
+                private_key: '/Users/inovakov/.ssh/id_ed25519'
+                ssh_command: 'ssh -i /Users/inovakov/.ssh/id_ed25519 -o SomeOption=yes'
+
+# The lines beneath this are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/README.md
+++ b/README.md
@@ -1,22 +1,32 @@
 # unique
 
-`unique` is simple tool that outputs the unique lines of its input. That input can come from `stdin` or from a file.
-
-The reason `unique` exists is that I need it. If it's useful to you as well - awesome!
+`unique` is a simple tool that outputs the unique lines of its input. That input can come from `stdin` or from a file.
 
 ## Installation
 
-If you have [Go](https://go.dev/) installed:
+### Use [Homebrew](https://brew.sh/):
+
+```shell
+brew install ro-tex/tap/unique
+```
+
+Or `brew tap ro-tex/tap` and then `brew install unique`.
+
+### Build it yourself:
+
+You will need [Go](https://go.dev/) for this.
 
 ```shell
 go install github.com/ro-tex/unique@latest
 ```
 
-If you prefer a binary, you can download a Linux amd64 one from https://github.com/ro-tex/unique/releases.
+### Grab a binary:
+
+If you prefer a binary, you can download a Linux or Mac one from https://github.com/ro-tex/unique/releases.
 
 ## Usage
 
-When no arguments are given, `unique` reads from the standard in.  
+When no arguments are given, `unique` reads from the standard in.
 Running
 
 ```shell
@@ -40,18 +50,4 @@ That is equivalent to
 
 ```shell
 cat file.dat | unique
-```
-
-## Development
-
-To run locally, run:
-
-```shell
-go run main.go <ARGS>
-```
-
-To install the local changes:
-
-```shell
-go install
 ```


### PR DESCRIPTION
This PR enables [GoReleaser](https://goreleaser.com/) and adds the project to my newly created [Homebrew tap](https://github.com/ro-tex/homebrew-tap).

GoReleaser is configured to build `arm64` and `amd64` Mac binaries, as well as `i386`, `arm64`, `amd64` Linux binaries.

Example usage:
```
git tag -a v0.0.5 -m "GoReleaser and Homebrew."
git push origin v0.0.5 
goreleaser release --clean
```